### PR TITLE
Fix code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/core/proj/srv.py
+++ b/core/proj/srv.py
@@ -72,7 +72,7 @@ class EPSGIO():
 			rq = Request(url, headers={'User-Agent': USER_AGENT})
 			response = urlopen(rq, timeout=REPROJ_TIMEOUT).read().decode('utf8')
 		except (URLError, HTTPError) as err:
-			log.error('Http request fails url:{}, code:{}, error:{}'.format(url, err.code, err.reason))
+			log.error('Http request failed with code:{}, error:{}'.format(err.code, err.reason))
 			raise
 
 		obj = json.loads(response)


### PR DESCRIPTION
Fixes [https://github.com/universalbit-dev/BlenderGIS/security/code-scanning/2](https://github.com/universalbit-dev/BlenderGIS/security/code-scanning/2)

To fix the problem, we should avoid logging the full URL and instead log a more generic message that does not include potentially sensitive information. We can log the error code and reason without including the URL. This way, we still retain useful debugging information without exposing sensitive data.

- Modify the log message on line 75 in `core/proj/srv.py` to exclude the URL.
- Ensure the log message still provides useful information for debugging by including the error code and reason.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
