### PR TITLE
Fix code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/core/proj/srv.py
+++ b/core/proj/srv.py
@@ -66,7 +66,7 @@ class EPSGIO():
 		url = url.replace("{CRS1}", str(epsg1))
 		url = url.replace("{CRS2}", str(epsg2))
 
-		log.debug(url)
+		log.debug('Request made to EPSG.io service')
 
 		try:
 			rq = Request(url, headers={'User-Agent': USER_AGENT})
@@ -110,7 +110,7 @@ class EPSGIO():
 		result = []
 		for part in parts:
 			url = urlTemplate.replace("{POINTS}", part)
-			log.debug(url)
+			log.debug('Request made to EPSG.io service')
 
 			try:
 				rq = Request(url, headers={'User-Agent': USER_AGENT})


### PR DESCRIPTION
Fixes [https://github.com/universalbit-dev/BlenderGIS/security/code-scanning/1](https://github.com/universalbit-dev/BlenderGIS/security/code-scanning/1)

To fix the problem, we should avoid logging sensitive information such as GPS coordinates. Instead of logging the full URL, we can log a sanitized version of the URL or a message indicating that a request was made without including sensitive details. This change should be made in the `core/proj/srv.py` file where the `url` variable is logged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
